### PR TITLE
Fix mobile Enter key advancing focus in PillsInput option fields

### DIFF
--- a/frontend/src/forms/items/ItemForm.tsx
+++ b/frontend/src/forms/items/ItemForm.tsx
@@ -356,6 +356,7 @@ export function ItemForm({ onItemSave, item }: Props) {
                                                     ))}
                                                     <PillsInput.Field
                                                         placeholder="Type option and press Enter"
+                                                        enterKeyHint="enter"
                                                         onKeyDown={(event) => {
                                                             if (event.key === "Enter") {
                                                                 event.preventDefault();
@@ -364,6 +365,11 @@ export function ItemForm({ onItemSave, item }: Props) {
                                                                     form.insertListItem(`attributesAndGroups.${index}.attribute.options`, value);
                                                                     event.currentTarget.value = "";
                                                                 }
+                                                            }
+                                                        }}
+                                                        onKeyUp={(event) => {
+                                                            if (event.key === "Enter") {
+                                                                event.preventDefault();
                                                             }
                                                         }}
                                                     />
@@ -518,6 +524,7 @@ export function ItemForm({ onItemSave, item }: Props) {
                                                                 ))}
                                                                 <PillsInput.Field
                                                                     placeholder="Type option and press Enter"
+                                                                    enterKeyHint="enter"
                                                                     onKeyDown={(event) => {
                                                                         if (event.key === "Enter") {
                                                                             event.preventDefault();
@@ -526,6 +533,11 @@ export function ItemForm({ onItemSave, item }: Props) {
                                                                                 form.insertListItem(`attributesAndGroups.${index}.group.attributes.${attrIndex}.options`, value);
                                                                                 event.currentTarget.value = "";
                                                                             }
+                                                                        }
+                                                                    }}
+                                                                    onKeyUp={(event) => {
+                                                                        if (event.key === "Enter") {
+                                                                            event.preventDefault();
                                                                         }
                                                                     }}
                                                                 />


### PR DESCRIPTION
Add enterKeyHint="enter" to tell mobile keyboards to show a return key
instead of a next/go key, and add onKeyUp preventDefault as a fallback
since some mobile browsers fire focus-advancement on keyup.

https://claude.ai/code/session_01GiwYCyp7aqX5SzTVB67DqA