### PR TITLE
Fix order taker category menu not scrolling horizontally

### DIFF
--- a/frontend/src/components/orders/ItemSelection.tsx
+++ b/frontend/src/components/orders/ItemSelection.tsx
@@ -126,9 +126,8 @@ export function ItemSelection ({currentSelection, onItemSelectionChange}: props)
                 background: 'white', // to cover what's underneath
                 paddingBottom: 8
             }}>
-                <ScrollArea scrollbarSize={6} type="scroll" offsetScrollbars >
+                <ScrollArea scrollbarSize={6} type="scroll" offsetScrollbars>
                     <SegmentedControl
-                        fullWidth
                         value={selectedCategory || undefined}
                         onChange={(val) => setSelectedCategory(val)}
                         data={Object.values(Category).map((category) => ({

--- a/frontend/src/components/orders/ItemSelection.tsx
+++ b/frontend/src/components/orders/ItemSelection.tsx
@@ -128,6 +128,7 @@ export function ItemSelection ({currentSelection, onItemSelectionChange}: props)
             }}>
                 <ScrollArea scrollbarSize={6} type="scroll" offsetScrollbars>
                     <SegmentedControl
+                        style={{ minWidth: '100%' }}
                         value={selectedCategory || undefined}
                         onChange={(val) => setSelectedCategory(val)}
                         data={Object.values(Category).map((category) => ({


### PR DESCRIPTION
The SegmentedControl had fullWidth set, which forced it to match its
container width and gave the ScrollArea nothing to overflow. Removing
fullWidth lets the control take its natural width so users can scroll
to categories like First Aid and Accessories on smaller/zoomed screens.

https://claude.ai/code/session_019akaTqhtCFNbV8BMfHy43x