### PR TITLE
Add Slack webhook integration for bug report notifications

### DIFF
--- a/src/main/java/com/mosaicchurchaustin/oms/client/SlackWebhookClient.java
+++ b/src/main/java/com/mosaicchurchaustin/oms/client/SlackWebhookClient.java
@@ -1,0 +1,94 @@
+package com.mosaicchurchaustin.oms.client;
+
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class SlackWebhookClient {
+
+    @Value("${slack.webhook.bugs:}")
+    private String bugsWebhookUrl;
+
+    private final OkHttpClient client = new OkHttpClient();
+
+    public void postBugReport(final String reporterName, final String title, final String description, final String adminUrl) {
+        if (!StringUtils.hasText(bugsWebhookUrl)) {
+            log.debug("Slack bugs webhook not configured, skipping notification.");
+            return;
+        }
+
+        final String json = String.format("""
+                {
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": { "type": "plain_text", "text": ":bug: New Bug Report", "emoji": true }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        { "type": "mrkdwn", "text": "*Reported by:*\\n%s" },
+                        { "type": "mrkdwn", "text": "*Title:*\\n%s" }
+                      ]
+                    },
+                    {
+                      "type": "section",
+                      "text": { "type": "mrkdwn", "text": "*Description:*\\n%s" }
+                    },
+                    {
+                      "type": "actions",
+                      "elements": [
+                        {
+                          "type": "button",
+                          "text": { "type": "plain_text", "text": "View Bug Reports" },
+                          "url": "%s"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """,
+                escapeJson(reporterName),
+                escapeJson(title),
+                escapeJson(description != null ? description : ""),
+                adminUrl);
+
+        final RequestBody body = RequestBody.create(json, MediaType.get("application/json; charset=utf-8"));
+        final Request request = new Request.Builder()
+                .url(bugsWebhookUrl)
+                .post(body)
+                .build();
+
+        try (final Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                log.debug("Bug report notification posted to Slack.");
+            } else {
+                final String responseBody = response.body() != null ? response.body().string() : "<empty body>";
+                log.error("Failed to post bug report to Slack. Response code: {}, body: {}", response.code(), responseBody);
+            }
+        } catch (final IOException e) {
+            log.error("IOException posting bug report to Slack", e);
+        } catch (final Exception e) {
+            log.error("Unexpected exception posting bug report to Slack", e);
+        }
+    }
+
+    private String escapeJson(final String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/src/main/java/com/mosaicchurchaustin/oms/services/BugReportService.java
+++ b/src/main/java/com/mosaicchurchaustin/oms/services/BugReportService.java
@@ -1,5 +1,6 @@
 package com.mosaicchurchaustin.oms.services;
 
+import com.mosaicchurchaustin.oms.client.SlackWebhookClient;
 import com.mosaicchurchaustin.oms.data.entity.BaseUuidEntity;
 import com.mosaicchurchaustin.oms.data.entity.BugReportEntity;
 import com.mosaicchurchaustin.oms.data.entity.user.UserEntity;
@@ -10,6 +11,7 @@ import com.mosaicchurchaustin.oms.repositories.BugReportRepository;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -24,6 +26,9 @@ import java.util.Optional;
 @Slf4j
 public class BugReportService {
 
+    @Value("${mosaic.oms.frontend.url}")
+    private String frontendUrl;
+
     @Autowired
     BugReportRepository bugReportRepository;
 
@@ -35,6 +40,9 @@ public class BugReportService {
 
     @Autowired
     TaskScheduler taskScheduler;
+
+    @Autowired
+    SlackWebhookClient slackWebhookClient;
 
     @Transactional
     public BugReportResponse createBugReport(final CreateBugReportRequest request) {
@@ -48,13 +56,19 @@ public class BugReportService {
                 .build();
 
         final BugReportEntity savedBugReport = bugReportRepository.save(bugReport);
-        
-        // Schedule PostHog event ID lookup 10 seconds after creation
+
         taskScheduler.schedule(
             () -> updatePostHogEventIdForBug(savedBugReport.getUuid()),
             Instant.now().plus(Duration.ofSeconds(10))
         );
-        
+
+        slackWebhookClient.postBugReport(
+            reporter.getName(),
+            savedBugReport.getTitle(),
+            savedBugReport.getDescription(),
+            frontendUrl + "/admin/bugs"
+        );
+
         return BugReportResponse.from(savedBugReport);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,10 @@ posthog:
 
 anthropic:
   api-key: ${ANTHROPIC_API_KEY:}
+
+slack:
+  webhook:
+    bugs: ${SLACK_WEBHOOK_BUGS:}
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Summary
Adds Slack webhook integration to notify a designated Slack channel when users submit bug reports through the application. This enables the team to be immediately aware of reported issues.

## Key Changes
- **New `SlackWebhookClient` component**: HTTP client that posts formatted bug reports to a Slack webhook URL
  - Constructs rich Slack Block Kit messages with bug details (reporter, title, description)
  - Includes a clickable button linking to the admin bug reports page
  - Implements proper JSON escaping for user-provided content
  - Gracefully handles missing webhook configuration and network errors with appropriate logging
  
- **Updated `BugReportService`**: Integrates Slack notifications into the bug report creation workflow
  - Injects `SlackWebhookClient` and frontend URL configuration
  - Calls `postBugReport()` immediately after saving a new bug report to the database
  - Passes reporter name, title, description, and admin URL to the webhook client

- **Configuration**: Added `slack.webhook.bugs` property to `application.yml`
  - Reads from `SLACK_WEBHOOK_BUGS` environment variable
  - Defaults to empty string (webhook notifications disabled if not configured)

## Implementation Details
- Uses OkHttpClient for HTTP requests with proper resource management (try-with-resources)
- Slack message format includes header, reporter/title fields, description section, and action button
- JSON escaping handles special characters in user input (quotes, newlines, backslashes, etc.)
- Comprehensive error handling with distinct logging for IO exceptions and unexpected errors
- Non-blocking: notification failures don't affect bug report creation or user experience

https://claude.ai/code/session_01Shi3JYept1WTYa1C5NsxWY